### PR TITLE
Ability to build logger with custom SinkFactories

### DIFF
--- a/config.go
+++ b/config.go
@@ -254,24 +254,16 @@ func (cfg Config) buildEncoder() (zapcore.Encoder, error) {
 
 // SinkFactory defines the Create() method used to create sink writers and
 // closers.
-type SinkFactory interface {
-	Create() (zapcore.WriteSyncer, io.Closer)
+type SinkFactory struct {
+	Writer zapcore.WriteSyncer
+	Closer io.Closer
 }
 
 // DefaultSinkFactories generates a map of regularly used sink factories,
 // like stdout and stderr.
 func DefaultSinkFactories() map[string]SinkFactory {
 	return map[string]SinkFactory{
-		"stdout": stdFactory{os.Stdout},
-		"stderr": stdFactory{os.Stderr},
+		"stdout": SinkFactory{os.Stdout, ioutil.NopCloser(os.Stdout)},
+		"stderr": SinkFactory{os.Stderr, ioutil.NopCloser(os.Stderr)},
 	}
-}
-
-type stdFactory struct {
-	io *os.File
-}
-
-// Create returns the wrapped io and a no-op closer.
-func (s stdFactory) Create() (zapcore.WriteSyncer, io.Closer) {
-	return s.io, ioutil.NopCloser(s.io)
 }

--- a/sink.go
+++ b/sink.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zap
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+
+	"go.uber.org/zap/zapcore"
+)
+
+var (
+	_sinkMutex      sync.RWMutex
+	errSinkNotFound = errors.New("sink for the given key not found")
+	_sinkFactories  = map[string]func() (Sink, error){
+		"stdout": func() (Sink, error) { return NopCloserSink{os.Stdout}, nil },
+		"stderr": func() (Sink, error) { return NopCloserSink{os.Stderr}, nil },
+	}
+)
+
+// Sink defines the interface to write to and close logger destinations.
+type Sink interface {
+	zapcore.WriteSyncer
+	io.Closer
+}
+
+// RegisterSink adds a Sink at the given key so it can be referenced
+// in config OutputPaths.
+func RegisterSink(key string, sinkFactory func() (Sink, error)) error {
+	_sinkMutex.Lock()
+	defer _sinkMutex.Unlock()
+	if key == "" {
+		return errors.New("sink key cannot be blank")
+	}
+	if _, ok := _sinkFactories[key]; ok {
+		return fmt.Errorf("sink already registered for key %q", key)
+	}
+	_sinkFactories[key] = sinkFactory
+	return nil
+}
+
+// newSink invokes the registered sink factory to create and return the
+// sink for the given key. Returns errSinkNotFound if the key cannot be found.
+func newSink(key string) (Sink, error) {
+	_sinkMutex.RLock()
+	defer _sinkMutex.RUnlock()
+	sinkFactory, ok := _sinkFactories[key]
+	if !ok {
+		return nil, errSinkNotFound
+	}
+	return sinkFactory()
+}
+
+// NopCloserSink wraps a WriteSyncer with a no-op Close() method.
+type NopCloserSink struct{ zapcore.WriteSyncer }
+
+// Close does nothing (no-op).
+func (NopCloserSink) Close() error { return nil }

--- a/sink_test.go
+++ b/sink_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zap
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRegisterSink(t *testing.T) {
+	tests := []struct {
+		name      string
+		key       string
+		factory   func() (Sink, error)
+		wantError bool
+	}{
+		{"valid", "valid", func() (Sink, error) { return NopCloserSink{os.Stdout}, nil }, false},
+		{"empty", "", func() (Sink, error) { return NopCloserSink{os.Stdout}, nil }, true},
+		{"stdout", "stdout", func() (Sink, error) { return NopCloserSink{os.Stdout}, nil }, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := RegisterSink(tt.key, tt.factory)
+			if tt.wantError {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+				assert.NotNil(t, _sinkFactories[tt.key], "expected the factory to be present")
+			}
+		})
+	}
+}
+
+func TestNewSink(t *testing.T) {
+	errTestSink := errors.New("test erroring")
+	err := RegisterSink("errors", func() (Sink, error) { return nil, errTestSink })
+	assert.Nil(t, err)
+	tests := []struct {
+		key string
+		err error
+	}{
+		{"stdout", nil},
+		{"errors", errTestSink},
+		{"nonexistent", errSinkNotFound},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			_, err := newSink(tt.key)
+			assert.Equal(t, tt.err, err)
+		})
+	}
+}

--- a/sink_test.go
+++ b/sink_test.go
@@ -35,9 +35,9 @@ func TestRegisterSink(t *testing.T) {
 		factory   func() (Sink, error)
 		wantError bool
 	}{
-		{"valid", "valid", func() (Sink, error) { return NopCloserSink{os.Stdout}, nil }, false},
-		{"empty", "", func() (Sink, error) { return NopCloserSink{os.Stdout}, nil }, true},
-		{"stdout", "stdout", func() (Sink, error) { return NopCloserSink{os.Stdout}, nil }, true},
+		{"valid", "valid", func() (Sink, error) { return nopCloserSink{os.Stdout}, nil }, false},
+		{"empty", "", func() (Sink, error) { return nopCloserSink{os.Stdout}, nil }, true},
+		{"stdout", "stdout", func() (Sink, error) { return nopCloserSink{os.Stdout}, nil }, true},
 	}
 
 	for _, tt := range tests {
@@ -54,6 +54,7 @@ func TestRegisterSink(t *testing.T) {
 }
 
 func TestNewSink(t *testing.T) {
+	defer resetSinkRegistry()
 	errTestSink := errors.New("test erroring")
 	err := RegisterSink("errors", func() (Sink, error) { return nil, errTestSink })
 	assert.Nil(t, err)
@@ -63,7 +64,7 @@ func TestNewSink(t *testing.T) {
 	}{
 		{"stdout", nil},
 		{"errors", errTestSink},
-		{"nonexistent", errSinkNotFound},
+		{"nonexistent", &errSinkNotFound{"nonexistent"}},
 	}
 
 	for _, tt := range tests {

--- a/writer.go
+++ b/writer.go
@@ -61,7 +61,7 @@ func open(sf map[string]SinkFactory, paths []string) ([]zapcore.WriteSyncer, fun
 	for _, path := range paths {
 		factory, ok := sf[path]
 		if ok {
-			writer, closer := factory.Create()
+			writer, closer := factory.Writer, factory.Closer
 			writers = append(writers, writer)
 			closers = append(closers, closer)
 			continue

--- a/writer.go
+++ b/writer.go
@@ -21,6 +21,7 @@
 package zap
 
 import (
+	"io"
 	"io/ioutil"
 	"os"
 
@@ -29,15 +30,17 @@ import (
 	"go.uber.org/multierr"
 )
 
-// Open is a high-level wrapper that takes a variadic number of paths, opens or
-// creates each of the specified files, and combines them into a locked
-// WriteSyncer. It also returns any error encountered and a function to close
-// any opened files.
+// Open is a high-level wrapper that takes a map of sink factories and a
+// variadic number of paths. The map of sink factories customize how to open
+// and close a particular path, with the default being the creation of a file
+// at said path.
+// It then combines all of the writers into a locked WriteSyncer. It also
+// returns any error encountered and a function to close any opened files.
 //
 // Passing no paths returns a no-op WriteSyncer. The special paths "stdout" and
 // "stderr" are interpreted as os.Stdout and os.Stderr, respectively.
-func Open(paths ...string) (zapcore.WriteSyncer, func(), error) {
-	writers, close, err := open(paths)
+func Open(sf map[string]SinkFactory, paths ...string) (zapcore.WriteSyncer, func(), error) {
+	writers, close, err := open(sf, paths)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -46,31 +49,28 @@ func Open(paths ...string) (zapcore.WriteSyncer, func(), error) {
 	return writer, close, nil
 }
 
-func open(paths []string) ([]zapcore.WriteSyncer, func(), error) {
+func open(sf map[string]SinkFactory, paths []string) ([]zapcore.WriteSyncer, func(), error) {
 	var openErr error
 	writers := make([]zapcore.WriteSyncer, 0, len(paths))
-	files := make([]*os.File, 0, len(paths))
+	closers := make([]io.Closer, 0, len(paths))
 	close := func() {
-		for _, f := range files {
-			f.Close()
+		for _, c := range closers {
+			c.Close()
 		}
 	}
 	for _, path := range paths {
-		switch path {
-		case "stdout":
-			writers = append(writers, os.Stdout)
-			// Don't close standard out.
-			continue
-		case "stderr":
-			writers = append(writers, os.Stderr)
-			// Don't close standard error.
+		factory, ok := sf[path]
+		if ok {
+			writer, closer := factory.Create()
+			writers = append(writers, writer)
+			closers = append(closers, closer)
 			continue
 		}
 		f, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0644)
 		openErr = multierr.Append(openErr, err)
 		if err == nil {
 			writers = append(writers, f)
-			files = append(files, f)
+			closers = append(closers, f)
 		}
 	}
 

--- a/writer_test.go
+++ b/writer_test.go
@@ -21,10 +21,10 @@
 package zap
 
 import (
-	"crypto/rand"
 	"encoding/hex"
 	"errors"
 	"io/ioutil"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"testing"
@@ -116,8 +116,9 @@ func (w *testWriter) Sync() error {
 }
 
 func TestOpenWithCustomSink(t *testing.T) {
+	defer resetSinkRegistry()
 	tw := &testWriter{"test", t}
-	ctr := func() (Sink, error) { return NopCloserSink{tw}, nil }
+	ctr := func() (Sink, error) { return nopCloserSink{tw}, nil }
 	assert.Nil(t, RegisterSink("TestOpenWithCustomSink", ctr))
 	w, cleanup, err := Open("TestOpenWithCustomSink")
 	assert.Nil(t, err)
@@ -126,6 +127,7 @@ func TestOpenWithCustomSink(t *testing.T) {
 }
 
 func TestOpenWithErroringSinkFactory(t *testing.T) {
+	defer resetSinkRegistry()
 	expectedErr := errors.New("expected factory error")
 	ctr := func() (Sink, error) { return nil, expectedErr }
 	assert.Nil(t, RegisterSink("TestOpenWithErroringSinkFactory", ctr))

--- a/writer_test.go
+++ b/writer_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func TestOpenNoPaths(t *testing.T) {
-	ws, cleanup, err := Open()
+	ws, cleanup, err := Open(DefaultSinkFactories())
 	defer cleanup()
 
 	assert.NoError(t, err, "Expected opening no paths to succeed.")
@@ -65,7 +65,7 @@ func TestOpen(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		wss, cleanup, err := open(tt.paths)
+		wss, cleanup, err := open(DefaultSinkFactories(), tt.paths)
 		if err == nil {
 			defer cleanup()
 		}
@@ -98,7 +98,7 @@ func TestOpenFails(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		_, cleanup, err := Open(tt.paths...)
+		_, cleanup, err := Open(DefaultSinkFactories(), tt.paths...)
 		require.Nil(t, cleanup, "Cleanup function should never be nil")
 		assert.Error(t, err, "Open with non-existent directory should fail")
 	}

--- a/writer_test.go
+++ b/writer_test.go
@@ -23,6 +23,7 @@ package zap
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -117,11 +118,19 @@ func (w *testWriter) Sync() error {
 func TestOpenWithCustomSink(t *testing.T) {
 	tw := &testWriter{"test", t}
 	ctr := func() (Sink, error) { return NopCloserSink{tw}, nil }
-	assert.Nil(t, RegisterSink("customsink", ctr))
-	w, cleanup, err := Open("customsink")
+	assert.Nil(t, RegisterSink("TestOpenWithCustomSink", ctr))
+	w, cleanup, err := Open("TestOpenWithCustomSink")
 	assert.Nil(t, err)
 	defer cleanup()
 	w.Write([]byte("test"))
+}
+
+func TestOpenWithErroringSinkFactory(t *testing.T) {
+	expectedErr := errors.New("expected factory error")
+	ctr := func() (Sink, error) { return nil, expectedErr }
+	assert.Nil(t, RegisterSink("TestOpenWithErroringSinkFactory", ctr))
+	_, _, err := Open("TestOpenWithErroringSinkFactory")
+	assert.Equal(t, expectedErr, err)
 }
 
 func TestCombineWriteSyncers(t *testing.T) {

--- a/writer_test.go
+++ b/writer_test.go
@@ -114,10 +114,11 @@ func (w *testWriter) Sync() error {
 	return nil
 }
 
-func TestOpenWithSinksCustomSink(t *testing.T) {
+func TestOpenWithCustomSink(t *testing.T) {
 	tw := &testWriter{"test", t}
-	sinks := map[string]Sink{"customsink": NopCloserSink{tw}}
-	w, cleanup, err := OpenWithSinks(sinks, "customsink")
+	ctr := func() (Sink, error) { return NopCloserSink{tw}, nil }
+	assert.Nil(t, RegisterSink("customsink", ctr))
+	w, cleanup, err := Open("customsink")
 	assert.Nil(t, err)
 	defer cleanup()
 	w.Write([]byte("test"))


### PR DESCRIPTION
Introduce the ability to pass in `Sink`s enabling one to customize a logger's `Writer` (technically `WriteSyncer`) and `Closer`.